### PR TITLE
add `libnewlib-arm-none-eabi` dep to thumb* targets.

### DIFF
--- a/docker/thumbv6m-none-eabi/Dockerfile
+++ b/docker/thumbv6m-none-eabi/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     gcc \
     gcc-arm-none-eabi \
     libc6-dev \
-    libnewlib-dev && \
+    libnewlib-dev \
+    libnewlib-arm-none-eabi && \
     curl -LSfs http://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/docker/thumbv7em-none-eabi/Dockerfile
+++ b/docker/thumbv7em-none-eabi/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     gcc \
     gcc-arm-none-eabi \
     libc6-dev \
-    libnewlib-dev && \
+    libnewlib-dev \
+    libnewlib-arm-none-eabi && \
     curl -LSfs http://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/docker/thumbv7em-none-eabihf/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     gcc \
     gcc-arm-none-eabi \
     libc6-dev \
-    libnewlib-dev && \
+    libnewlib-dev \
+    libnewlib-arm-none-eabi && \
     curl -LSfs http://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/docker/thumbv7m-none-eabi/Dockerfile
+++ b/docker/thumbv7m-none-eabi/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     gcc \
     gcc-arm-none-eabi \
     libc6-dev \
-    libnewlib-dev && \
+    libnewlib-dev \
+    libnewlib-arm-none-eabi && \
     curl -LSfs http://japaric.github.io/trust/install.sh | \
     sh -s -- --git japaric/xargo --tag v0.3.1 --target x86_64-unknown-linux-gnu --to /usr/bin


### PR DESCRIPTION
Adds `libc.a`, `libm.a`, `crt0.o` and more.

This adds 73.17 MB to the image however.