### PR TITLE
Individually set OPENSSL_INCLUDE_DIR and OPENSSL_LIB_DIR instead of OPENSSL_DIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ install:
   - curl https://sh.rustup.rs -sSf |
     sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
   - source ~/.cargo/env
-
+  - cargo clone -V || cargo install cargo-clone --vers 0.1.0
+  
 script:
   - bash ci/script.sh
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ where libc was extracted.
   ever write to `$OUT_DIR` and never modify `$CARGO_MANIFEST_DIR` though.
 
 - Versions `0.7.*` and older of the `openssl` crate are NOT supported. `cross`
-  supports `openssl` via the `OPENSSL_DIR` "feature", which seems to have been
-  introduced in `0.8.*`. There's no work around, other than bumping the
-  `openssl` dependency of the crates you are using.
+  supports `openssl` via the `OPENSSL_INCLUDE_DIR` and `OPENSSL_LIB_DIR`
+  environment variables, that have been introduced in `0.8.*`. There's no work
+  around, other than bumping the `openssl` dependency of the crates you are
+  using.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,12 +124,6 @@ where libc was extracted.
   to modify its "source", the build will fail. Well behaved crates should only
   ever write to `$OUT_DIR` and never modify `$CARGO_MANIFEST_DIR` though.
 
-- Versions `0.7.*` and older of the `openssl` crate are NOT supported. `cross`
-  supports `openssl` via the `OPENSSL_INCLUDE_DIR` and `OPENSSL_LIB_DIR`
-  environment variables, that have been introduced in `0.8.*`. There's no work
-  around, other than bumping the `openssl` dependency of the crates you are
-  using.
-
 ## License
 
 Licensed under either of

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -147,6 +147,19 @@ EOF
             rm -rf $td
             ;;
     esac
+
+    # Test openssl compatibility
+    if [ ! -z "$OPENSSL_INCLUDE_PATH" -a ! -z "$OPENSSL_LIB_PATH" ]; then
+            td=$(mktemp -d)
+
+            pushd $td
+            cargo clone openssl-sys --vers 0.5.5
+            cd openssl-sys
+            cross build --target $TARGET
+            popd
+
+            rm -rf $td
+    fi
 }
 
 main

--- a/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
     CC_arm_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
     CXX_arm_unknown_linux_gnueabi=arm-linux-gnueabi-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
     RUST_TEST_THREADS=1

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -27,6 +27,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/docker/i686-unknown-freebsd/Dockerfile
+++ b/docker/i686-unknown-freebsd/Dockerfile
@@ -19,4 +19,4 @@ RUN bash /freebsd.sh i686 && \
 
 ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER=i686-unknown-freebsd10-gcc \
     CC_i686_unknown_freebsd=i686-unknown-freebsd10-gcc \
-    OPENSSL_DIR=/openssl
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/docker/i686-unknown-linux-gnu/Dockerfile
@@ -22,4 +22,4 @@ RUN apt-get install -y --no-install-recommends \
     g++-multilib && \
     bash /openssl.sh 1.0.2j linux-elf "" -m32
 
-ENV OPENSSL_DIR=/openssl
+ENV OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/docker/mips-unknown-linux-gnu/Dockerfile
@@ -26,6 +26,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
     CC_mips_unknown_linux_gnu=mips-linux-gnu-gcc \
     CXX_mips_unknown_linux_gnu=mips-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/mips-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
     CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
     CXX_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \
     RUST_TEST_THREADS=1

--- a/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-gcc \
     CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc \
     CXX_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64 \
     RUST_TEST_THREADS=1

--- a/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
     CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc \
     CXX_mipsel_unknown_linux_gnu=mipsel-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
     CC_powerpc_unknown_linux_gnu=powerpc-linux-gnu-gcc \
     CXX_powerpc_unknown_linux_gnu=powerpc-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -26,6 +26,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
     CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
     CXX_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
     CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
     CXX_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
     CC_s390x_unknown_linux_gnu=s390x-linux-gnu-gcc \
     CXX_s390x_unknown_linux_gnu=s390x-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/s390x-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/sparc64-unknown-linux-gnu/Dockerfile
+++ b/docker/sparc64-unknown-linux-gnu/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get install -y --no-install-recommends \
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
     CXX_sparc64_unknown_linux_gnu=sparc64-linux-gnu-g++ \
-    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib \
     QEMU_LD_PREFIX=/usr/sparc64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/docker/x86_64-unknown-dragonfly/Dockerfile
+++ b/docker/x86_64-unknown-dragonfly/Dockerfile
@@ -19,4 +19,4 @@ RUN bash /dragonfly.sh && \
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_DRAGONFLY_LINKER=x86_64-unknown-dragonfly-gcc \
     CC_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-gcc \
-    OPENSSL_DIR=/openssl
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/docker/x86_64-unknown-freebsd/Dockerfile
@@ -19,4 +19,4 @@ RUN bash /freebsd.sh x86_64 && \
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd10-gcc \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-gcc \
-    OPENSSL_DIR=/openssl
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get install -y --no-install-recommends \
     zlib1g-dev && \
     bash /openssl.sh 1.0.2j linux-x86_64
 
-ENV OPENSSL_DIR=/openssl
+ENV OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -20,4 +20,4 @@ RUN bash /musl.sh 1.1.15 && \
     bash /openssl.sh 1.0.2j linux-x86_64 musl- -static
 
 ENV CC_x86_64_unknown_linux_musl=musl-gcc \
-    OPENSSL_DIR=/openssl
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-netbsd/Dockerfile
+++ b/docker/x86_64-unknown-netbsd/Dockerfile
@@ -19,4 +19,4 @@ RUN bash /netbsd.sh && \
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_NETBSD_LINKER=x86_64-unknown-netbsd-gcc \
     CC_x86_64_unknown_netbsd=x86_64-unknown-netbsd-gcc \
-    OPENSSL_DIR=/openssl
+    OPENSSL_INCLUDE_DIR=/openssl/include OPENSSL_LIB_DIR=/openssl/lib


### PR DESCRIPTION
This makes cross compatible with a wider range of openssl versions.