### PR TITLE
Use `cargo fetch` instead of `cargo generate-lockfile`

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -59,7 +59,7 @@ pub fn run(target: &Target,
     // We create/regenerate the lockfile on the host system because the Docker
     // container doesn't have write access to the root of the Cargo project
     let cargo_toml = root.join("Cargo.toml");
-    Command::new("cargo").args(&["generate-lockfile",
+    Command::new("cargo").args(&["fetch",
                 "--manifest-path",
                 &cargo_toml.display().to_string()])
         .run(verbose)


### PR DESCRIPTION
This allows offline work, as `cargo fetch` only updates the lockfile if
necessary, whereas `cargo generate-lockfile` basically does a remove and
regenerate.