### PR TITLE
Add support for whitelisting environment variables to pass through (closes #76)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -426,6 +426,37 @@ impl Toml {
             Ok(None)
         }
     }
+
+    /// Returns the `build.env.whitelist` part of `Cross.toml`
+    pub fn env_whitelist(&self) -> Result<Vec<&str>> {
+        if let Some(value) = self.table.lookup("build.env.whitelist") {
+            if let Some(arr) = value.as_slice() {
+                arr.iter()
+                    .map(|v| {
+                        v.as_str()
+                            .ok_or_else(|| {
+                                "every build.env.whitelist element must be a string".into()
+                            })
+                    })
+                    .collect()
+            } else {
+                Err("build.env.whitelist must be an array".into())
+            }
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Returns the `build.env.whitelist_all` part of `Cross.toml`
+    pub fn env_whitelist_all(&self) -> Result<Option<bool>> {
+        if let Some(value) = self.table.lookup("build.env.whitelist_all") {
+            value.as_bool()
+                .ok_or_else(|| "build.env.whitelist_all must be a boolean".into())
+                .map(Some)
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// Parses the `Cross.toml` at the root of the Cargo project (if any)


### PR DESCRIPTION
This adds a fairly straight-forward section to `Cross.toml` like so:

```toml
[build.env]
whitelist_all = true
# ...or...
whitelist = ["PATH", "RVM_VERSION", "LD_LIBRARY_PATH"]
```