### PR TITLE
Allow passing through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,26 +116,29 @@ $ docker build -t my/image:tag path/to/where/the/Dockerfile/resides
 ### Passing environment variables into the build environemnt
 
 By default, `cross` does not pass any environment variables into the build
-environment from the calling shell. Sometimes this is really useful, for
-example to pass in environment variables set by your CI system.
+environment from the calling shell. This is chosen as a safe default as most use
+cases will not want the calling environment leaking into the inner execution
+environment.
 
-To whitelist some variables, you can specify them in your `Cross.toml`
-like so
+In the instances that you do want to pass through environment variables, this
+can be done via `build.env.passthrough` in your `Cross.toml`:
+
 
 ```toml
 [build.env]
-whitelist = [
-    "TRAVIS",
+passthrough = [
+    "RUST_BACKTRACE",
     "RUST_LOG",
+    "TRAVIS",
 ]
 ```
 
-To whitelist some variables for one target but not others, you can use
-this syntax instead
+To pass variables through for one target but not others, you can use
+this syntax instead:
 
 ```toml
 [target.aarch64-unknown-linux-gnu.env]
-whitelist = [
+passthrough = [
     "RUST_DEBUG",
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -113,6 +113,33 @@ RUN dpkg --add-architecture arm64 && \
 $ docker build -t my/image:tag path/to/where/the/Dockerfile/resides
 ```
 
+### Passing environment variables into the build environemnt
+
+By default, `cross` does not pass any environment variables into the build
+environment from the calling shell. Sometimes this is really useful, for
+example to pass in environment variables set by your CI system.
+
+To whitelist some variables, you can specify them in your `Cross.toml`
+like so
+
+```toml
+[build.env]
+whitelist = [
+    "TRAVIS",
+    "RUST_LOG",
+]
+```
+
+To whitelist some variables for one target but not others, you can use
+this syntax instead
+
+```toml
+[target.aarch64-unknown-linux-gnu.env]
+whitelist = [
+    "RUST_DEBUG",
+]
+```
+
 ### Use Xargo instead of Cargo
 
 By default, `cross` uses `cargo` to build your Cargo project *unless* you are

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -120,7 +120,7 @@ pub fn run(target: &Target,
     }
 
     if let Some(toml) = toml {
-        for var in toml.env_whitelist()? {
+        for var in toml.env_whitelist(target)? {
             if var.contains("=") {
                 bail!("environment variable names must not contain the '=' character");
             }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -119,6 +119,26 @@ pub fn run(target: &Target,
         docker.args(&["-e", &format!("QEMU_STRACE={}", strace)]);
     }
 
+    if let Some(toml) = toml {
+        if toml.env_whitelist_all()?.unwrap_or(false) {
+            for (var, _) in env::vars() {
+                // Only specifying the environment variable name in the "-e"
+                // flag forwards the value from the parent shell
+                docker.args(&["-e", &var]);
+            }
+        } else {
+            for var in toml.env_whitelist()? {
+                if var.contains("=") {
+                    return Err("environment variable names must not contain the '=' character".into())
+                }
+
+                // Only specifying the environment variable name in the "-e"
+                // flag forwards the value from the parent shell
+                docker.args(&["-e", var]);
+            }
+        }
+    }
+
     docker
         .args(&["-e", "XARGO_HOME=/xargo"])
         .args(&["-v", &format!("{}:/xargo", xargo_dir.display())])

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -120,7 +120,7 @@ pub fn run(target: &Target,
     }
 
     if let Some(toml) = toml {
-        for var in toml.env_whitelist(target)? {
+        for var in toml.env_passthrough(target)? {
             if var.contains("=") {
                 bail!("environment variable names must not contain the '=' character");
             }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -120,22 +120,14 @@ pub fn run(target: &Target,
     }
 
     if let Some(toml) = toml {
-        if toml.env_whitelist_all()?.unwrap_or(false) {
-            for (var, _) in env::vars() {
-                // Only specifying the environment variable name in the "-e"
-                // flag forwards the value from the parent shell
-                docker.args(&["-e", &var]);
+        for var in toml.env_whitelist()? {
+            if var.contains("=") {
+                bail!("environment variable names must not contain the '=' character");
             }
-        } else {
-            for var in toml.env_whitelist()? {
-                if var.contains("=") {
-                    return Err("environment variable names must not contain the '=' character".into())
-                }
 
-                // Only specifying the environment variable name in the "-e"
-                // flag forwards the value from the parent shell
-                docker.args(&["-e", var]);
-            }
+            // Only specifying the environment variable name in the "-e"
+            // flag forwards the value from the parent shell
+            docker.args(&["-e", var]);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,22 +478,22 @@ impl Toml {
         }
     }
 
-    /// Returns the environment variable whitelist for `target`, including variables sepcified
-    /// under `build` and under `target`.
-    pub fn env_whitelist(&self, target: &Target) -> Result<Vec<&str>> {
-        let mut bwl = self.build_env_whitelist()?;
-        let mut twl = self.target_env_whitelist(target)?;
+    /// Returns the list of environment variables to pass through for `target`,
+    /// including variables sepcified under `build` and under `target`.
+    pub fn env_passthrough(&self, target: &Target) -> Result<Vec<&str>> {
+        let mut bwl = self.build_env_passthrough()?;
+        let mut twl = self.target_env_passthrough(target)?;
         bwl.extend(twl.drain(..));
 
         Ok(bwl)
     }
 
-    /// Returns the `build.env.whitelist` part of `Cross.toml`
-    fn build_env_whitelist(&self) -> Result<Vec<&str>> {
-        match self.table.lookup("build.env.whitelist") {
+    /// Returns the `build.env.passthrough` part of `Cross.toml`
+    fn build_env_passthrough(&self) -> Result<Vec<&str>> {
+        match self.table.lookup("build.env.passthrough") {
             Some(&Value::Array(ref vec)) => {
                 if vec.iter().any(|val| val.as_str().is_none()) {
-                    bail!("every build.env.whitelist element must be a string");
+                    bail!("every build.env.passthrough element must be a string");
                 }
                 Ok(vec.iter().map(|val| val.as_str().unwrap()).collect())
             },
@@ -501,11 +501,11 @@ impl Toml {
         }
     }
 
-    /// Returns the `target.<triple>.env.whitelist` part of `Cross.toml` for `target`.
-    fn target_env_whitelist(&self, target: &Target) -> Result<Vec<&str>> {
+    /// Returns the `target.<triple>.env.passthrough` part of `Cross.toml` for `target`.
+    fn target_env_passthrough(&self, target: &Target) -> Result<Vec<&str>> {
         let triple = target.triple();
 
-        let key = format!("target.{}.env.whitelist", triple);
+        let key = format!("target.{}.env.passthrough", triple);
 
         match self.table.lookup(&key) {
             Some(&Value::Array(ref vec)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,7 +479,7 @@ impl Toml {
     }
 
     /// Returns the list of environment variables to pass through for `target`,
-    /// including variables sepcified under `build` and under `target`.
+    /// including variables specified under `build` and under `target`.
     pub fn env_passthrough(&self, target: &Target) -> Result<Vec<&str>> {
         let mut bwl = self.build_env_passthrough()?;
         let mut twl = self.target_env_passthrough(target)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,6 +477,37 @@ impl Toml {
             Ok(None)
         }
     }
+
+    /// Returns the `build.env.whitelist` part of `Cross.toml`
+    pub fn env_whitelist(&self) -> Result<Vec<&str>> {
+        if let Some(value) = self.table.lookup("build.env.whitelist") {
+            if let Some(arr) = value.as_slice() {
+                arr.iter()
+                    .map(|v| {
+                        v.as_str()
+                            .ok_or_else(|| {
+                                "every build.env.whitelist element must be a string".into()
+                            })
+                    })
+                    .collect()
+            } else {
+                Err("build.env.whitelist must be an array".into())
+            }
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Returns the `build.env.whitelist_all` part of `Cross.toml`
+    pub fn env_whitelist_all(&self) -> Result<Option<bool>> {
+        if let Some(value) = self.table.lookup("build.env.whitelist_all") {
+            value.as_bool()
+                .ok_or_else(|| "build.env.whitelist_all must be a boolean".into())
+                .map(Some)
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// Parses the `Cross.toml` at the root of the Cargo project (if any)

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,17 +497,6 @@ impl Toml {
             Ok(Vec::new())
         }
     }
-
-    /// Returns the `build.env.whitelist_all` part of `Cross.toml`
-    pub fn env_whitelist_all(&self) -> Result<Option<bool>> {
-        if let Some(value) = self.table.lookup("build.env.whitelist_all") {
-            value.as_bool()
-                .ok_or_else(|| "build.env.whitelist_all must be a boolean".into())
-                .map(Some)
-        } else {
-            Ok(None)
-        }
-    }
 }
 
 /// Parses the `Cross.toml` at the root of the Cargo project (if any)

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,21 +490,14 @@ impl Toml {
 
     /// Returns the `build.env.whitelist` part of `Cross.toml`
     fn build_env_whitelist(&self) -> Result<Vec<&str>> {
-        if let Some(value) = self.table.lookup("build.env.whitelist") {
-            if let Some(arr) = value.as_slice() {
-                arr.iter()
-                    .map(|v| {
-                        v.as_str()
-                            .ok_or_else(|| {
-                                "every build.env.whitelist element must be a string".into()
-                            })
-                    })
-                    .collect()
-            } else {
-                Err("build.env.whitelist must be an array".into())
-            }
-        } else {
-            Ok(Vec::new())
+        match self.table.lookup("build.env.whitelist") {
+            Some(&Value::Array(ref vec)) => {
+                if vec.iter().any(|val| val.as_str().is_none()) {
+                    bail!("every build.env.whitelist element must be a string");
+                }
+                Ok(vec.iter().map(|val| val.as_str().unwrap()).collect())
+            },
+            _ => Ok(Vec::new()),
         }
     }
 


### PR DESCRIPTION
This adapts @dflemstr's work in #77, removing the `whitelist_all` functionality as requested in review.

fixes #76 
closes #77