### PR TITLE
Add armv5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ worst, "hang" (never terminate).
 | `arm-linux-androideabi`              | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
 | `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.15 | 5.3.1   | N/A     |     | 2.8.0 |   ✓    |
-| `armel-unknown-linux-gnueabi`        | 2.19   | 4.9.2   | 1.0.2k  | ✓   | 2.9.0 |   ✓    |
-| `armv7-linux-androideabi` [5]        | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `armel-unknown-linux-gnueabi` [5]    | 2.19   | 4.9.2   | 1.0.2k  | ✓   | 2.9.0 |   ✓    |
+| `armv7-linux-androideabi`            | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
 | `armv7-unknown-linux-gnueabihf`      | 2.15   | 4.6.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
 | `armv7-unknown-linux-musleabihf`     | 1.1.15 | 5.3.1   | N/A     |     | 2.8.0 |   ✓    |
 | `asmjs-unknown-emscripten` [4]       | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ worst, "hang" (never terminate).
 | `arm-linux-androideabi`              | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
 | `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.15 | 5.3.1   | N/A     |     | 2.8.0 |   ✓    |
-| `armv7-linux-androideabi`            | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `armel-unknown-linux-gnueabi`        | 2.19   | 4.9.2   | 1.0.2k  | ✓   | 2.9.0 |   ✓    |
+| `armv7-linux-androideabi` [5]        | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
 | `armv7-unknown-linux-gnueabihf`      | 2.15   | 4.6.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
 | `armv7-unknown-linux-musleabihf`     | 1.1.15 | 5.3.1   | N/A     |     | 2.8.0 |   ✓    |
 | `asmjs-unknown-emscripten` [4]       | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
@@ -231,6 +232,8 @@ where libc was extracted.
 
 [4] libc = musl, gcc = emcc; Some projects that use libc may fail due to wrong
     definitions (will be fixed by https://github.com/rust-lang/libc/pull/610)
+
+[5] armel = armv5te; See [Target Notes](./TARGET-NOTES.md#armv5) for additional info
 
 ## Debugging
 

--- a/TARGET-NOTES.md
+++ b/TARGET-NOTES.md
@@ -1,0 +1,6 @@
+# Target Notes
+
+This page details target specific information when using `cross`.
+
+## ARMv5
+

--- a/TARGET-NOTES.md
+++ b/TARGET-NOTES.md
@@ -4,3 +4,68 @@ This page details target specific information when using `cross`.
 
 ## ARMv5
 
+### Background
+
+Currently, Rust's built-in definition for the ARM9 family of processors with glibc support (referred to as `armel-unknown-linux-gnueabi` by GCC, and `armv5te-unknown-linux-gnueabi` by Rust/LLVM) defines `max-atomic-width` as `0`, as there is no hardware-level support for atomic operations. However when linked with `libgcc`, there are atomic primatives provided by the operating system. Additionally, this target uses the system allocator rather than jemalloc, as jemalloc does not currently build for this target. `unwind` is also not supported, so `panic` will abort.
+
+This `cross` target uses those OS intrinsics to provided atomic operations, and uses the gcc name of `armel-unknown-linux-gnueabi` to avoid aliasing the builtin specification.
+
+Previous discussion of this topic is available [in this reddit thread](https://www.reddit.com/r/rust/comments/64j39d/crosscompiling_for_arm926ejs/)
+
+### Integration steps
+
+Depending on which version of Rust you are using, the integration steps differ.
+
+#### Rust 1.19.0 and before
+
+Edit your `Cargo.toml`. Make sure the following sections are included:
+
+```toml
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+debug = true
+panic = "abort"
+```
+
+Create a file in your project directory (next to `Cargo.toml`) called `Xargo.toml`. This file should have the following contents:
+
+```toml
+[target.armel-unknown-linux-gnueabi.dependencies.std]
+default-features = false
+features=["panic_abort", "force_alloc_system"]
+```
+
+#### Rust 1.20.0 and above
+
+Edit your `Cargo.toml`. Make sure the following sections are included:
+
+```toml
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+debug = true
+panic = "abort"
+```
+
+Create a file in your project directory (next to `Cargo.toml`) called `Xargo.toml`. This file should have the following contents:
+
+```toml
+[target.armel-unknown-linux-gnueabi.dependencies.std]
+default-features = false
+features=["panic_abort"]
+```
+
+In your `main.rs`, add this to the top of your file:
+
+```rust
+#![feature(global_allocator)]
+#![feature(allocator_api)]
+
+use std::heap::System;
+
+#[global_allocator]
+static mut SYSTEM_ALLOCATOR: System = System;
+```

--- a/docker/armel-unknown-linux-gnueabi/Dockerfile
+++ b/docker/armel-unknown-linux-gnueabi/Dockerfile
@@ -36,7 +36,7 @@ ENV CARGO_TARGET_ARMEL_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
     HOST=x86_64-unknown-linux-gnu \
     CC_armel_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
     CXX_armel_unknown_linux_gnueabi=arm-linux-gnueabi-g++ \
-    CFLAGS_armel_unknown_linux_gnueabi="-Wall -Os -fPIC -D__arm__ -mfloat-abi=soft" \
+    CFLAGS_armel_unknown_linux_gnueabi="-march=armv5te -Wall -Os -fPIC -D__arm__ -mfloat-abi=soft" \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \

--- a/docker/armel-unknown-linux-gnueabi/Dockerfile
+++ b/docker/armel-unknown-linux-gnueabi/Dockerfile
@@ -1,12 +1,17 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y software-properties-common wget curl
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    software-properties-common \
+    wget \
+    curl
 
 RUN add-apt-repository "deb http://emdebian.org/tools/debian/ jessie main" && \
     curl http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add - && \
     dpkg --add-architecture armel && \
     apt-get update && \
-    apt-get install -y crossbuild-essential-armel
+    apt-get install -y --no-install-recommends \
+    crossbuild-essential-armel
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -24,11 +29,14 @@ COPY openssl.sh qemu.sh /
 RUN bash /openssl.sh linux-armv4 arm-linux-gnueabi- && \
     bash /qemu.sh arm
 
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_OSATOMIC_LINKER=arm-linux-gnueabi-gcc \
+COPY armel-unknown-linux-gnueabi/armel-unknown-linux-gnueabi.json /json/armel-unknown-linux-gnueabi.json
+
+ENV CARGO_TARGET_ARMEL_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
+    RUST_TARGET_PATH=/json \
     HOST=x86_64-unknown-linux-gnu \
-    CC_armv5te_unknown_linux_gnueabi_osatomic=arm-linux-gnueabi-gcc \
-    CXX_armv5te_unknown_linux_gnueabi_osatomic=arm-linux-gnueabi-g++ \
-    CFLAGS_armv5te_unknown_linux_gnueabi_osatomic="-Wall -Os -fPIC -D__arm__ -mfloat-abi=soft" \
+    CC_armel_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
+    CXX_armel_unknown_linux_gnueabi=arm-linux-gnueabi-g++ \
+    CFLAGS_armel_unknown_linux_gnueabi="-Wall -Os -fPIC -D__arm__ -mfloat-abi=soft" \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \

--- a/docker/armel-unknown-linux-gnueabi/armel-unknown-linux-gnueabi.json
+++ b/docker/armel-unknown-linux-gnueabi/armel-unknown-linux-gnueabi.json
@@ -1,0 +1,37 @@
+{
+  "abi-blacklist": [
+    "stdcall",
+    "fastcall",
+    "vectorcall",
+    "thiscall",
+    "win64",
+    "sysv64"
+  ],
+  "arch": "arm",
+  "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "exe-allocation-crate": "alloc_system",
+  "lib-allocation-crate": "alloc_system",
+  "executables": true,
+  "features": "+soft-float,+strict-align",
+  "has-elf-tls": true,
+  "has-rpath": true,
+  "is-builtin": false,
+  "linker-flavor": "gcc",
+  "linker-is-gnu": true,
+  "llvm-target": "armv5te-unknown-linux-gnueabi",
+  "max-atomic-width": 32,
+  "os": "linux",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gcc": [
+      "-Wl,--as-needed",
+      "-Wl,-z,noexecstack"
+    ]
+  },
+  "target-endian": "little",
+  "target-family": "unix",
+  "target-pointer-width": "32",
+  "vendor": "unknown"
+}

--- a/docker/armv5te-unknown-linux-gnueabi/Dockerfile
+++ b/docker/armv5te-unknown-linux-gnueabi/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y software-properties-common wget curl
+
+RUN add-apt-repository "deb http://emdebian.org/tools/debian/ jessie main" && \
+    curl http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add - && \
+    dpkg --add-architecture armel && \
+    apt-get update && \
+    apt-get install -y crossbuild-essential-armel
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    gcc \
+    libc6-dev \
+    make \
+    pkg-config
+
+COPY xargo.sh /
+RUN bash /xargo.sh
+
+COPY openssl.sh qemu.sh /
+RUN bash /openssl.sh linux-armv4 arm-linux-gnueabi- && \
+    bash /qemu.sh arm
+
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_OSATOMIC_LINKER=arm-linux-gnueabi-gcc \
+    HOST=x86_64-unknown-linux-gnu \
+    CC_armv5te_unknown_linux_gnueabi_osatomic=arm-linux-gnueabi-gcc \
+    CXX_armv5te_unknown_linux_gnueabi_osatomic=arm-linux-gnueabi-g++ \
+    CFLAGS_armv5te_unknown_linux_gnueabi_osatomic="-Wall -Os -fPIC -D__arm__ -mfloat-abi=soft" \
+    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include \
+    OPENSSL_LIB_DIR=/openssl/lib \
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
+    RUST_TEST_THREADS=1
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ impl Target {
     fn is_builtin(&self) -> bool {
         match *self {
             Target::Custom { .. } => false,
+            Target::ArmelUnknownLinuxGnueabi => false,
             _ => true,
         }
     }
@@ -211,13 +212,6 @@ impl Target {
         match *self {
             Target::I686PcWindowsGnu => true,
             Target::X86_64PcWindowsGnu => true,
-            _ => false,
-        }
-    }
-
-    fn needs_std_rebuilt(&self) -> bool {
-        match *self {
-            Target::ArmelUnknownLinuxGnueabi => true,
             _ => false,
         }
     }
@@ -293,7 +287,7 @@ impl Target {
     }
 
     fn needs_xargo(&self) -> bool {
-        self.is_bare_metal() || self.needs_std_rebuilt() || !self.is_builtin()
+        self.is_bare_metal() || !self.is_builtin()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,9 @@ pub enum Target {
     X86_64UnknownLinuxGnu,
     X86_64UnknownLinuxMusl,
 
+    // Linux, but must rebuild std
+    ArmelUnknownLinuxGnueabi,
+
     // *BSD
     I686UnknownFreebsd,
     X86_64UnknownDragonfly,
@@ -212,6 +215,13 @@ impl Target {
         }
     }
 
+    fn needs_std_rebuilt(&self) -> bool {
+        match *self {
+            Target::ArmelUnknownLinuxGnueabi => true,
+            _ => false,
+        }
+    }
+
     fn needs_docker(&self) -> bool {
         self.is_linux() || self.is_android() || self.is_bare_metal() || self.is_bsd() ||
         !self.is_builtin() || self.is_windows() || self.is_emscripten()
@@ -246,6 +256,7 @@ impl Target {
             ArmLinuxAndroideabi => "arm-linux-androideabi",
             ArmUnknownLinuxGnueabi => "arm-unknown-linux-gnueabi",
             ArmUnknownLinuxMusleabi => "arm-unknown-linux-musleabi",
+            ArmelUnknownLinuxGnueabi => "armel-unknown-linux-gnueabi",
             Armv7LinuxAndroideabi => "armv7-linux-androideabi",
             Armv7UnknownLinuxGnueabihf => "armv7-unknown-linux-gnueabihf",
             Armv7UnknownLinuxMusleabihf => "armv7-unknown-linux-musleabihf",
@@ -282,7 +293,7 @@ impl Target {
     }
 
     fn needs_xargo(&self) -> bool {
-        self.is_bare_metal() || !self.is_builtin()
+        self.is_bare_metal() || self.needs_std_rebuilt() || !self.is_builtin()
     }
 }
 
@@ -296,6 +307,7 @@ impl Target {
             "arm-linux-androideabi" => ArmLinuxAndroideabi,
             "arm-unknown-linux-gnueabi" => ArmUnknownLinuxGnueabi,
             "arm-unknown-linux-musleabi" => ArmUnknownLinuxMusleabi,
+            "armel-unknown-linux-gnueabi" => ArmelUnknownLinuxGnueabi,
             "armv7-linux-androideabi" => Armv7LinuxAndroideabi,
             "armv7-unknown-linux-gnueabihf" => Armv7UnknownLinuxGnueabihf,
             "armv7-unknown-linux-musleabihf" => Armv7UnknownLinuxMusleabihf,


### PR DESCRIPTION
Hey @japaric, heres a PR to integrate my work on ARMv5. Please let me know if you have any questions.

The changes to `cross` source should prevent the need for a `Cross.toml`, however as `jemalloc` and `unwind` are not available, it is still necessary to define a `Xargo.toml`, and make changes to `Cargo.toml` (as well as `main.rs` in Rust >= 1.20.0). These are detailed in `TARGET-NOTES.md`.