### PR TITLE
Add limited android test support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-musl                     STD=1 OPENSSL=0.5.5  RUN=1 DEPLOY=1
 
     # Android
-    - env: TARGET=aarch64-linux-android           CPP=1         STD=1 OPENSSL=0.5.5
-    - env: TARGET=arm-linux-androideabi           CPP=1         STD=1 OPENSSL=0.5.5
-    - env: TARGET=armv7-linux-androideabi         CPP=1         STD=1 OPENSSL=0.5.5
-    - env: TARGET=i686-linux-android              CPP=1         STD=1 OPENSSL=0.5.5
-    - env: TARGET=x86_64-linux-android            CPP=1         STD=1 OPENSSL=0.5.5
+    - env: TARGET=aarch64-linux-android           CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=arm-linux-androideabi           CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=armv7-linux-androideabi         CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=i686-linux-android              CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
+    - env: TARGET=x86_64-linux-android            CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
 
     # OSX
     - env: TARGET=i686-apple-darwin                     DYLIB=1 STD=1                RUN=1
@@ -41,7 +41,7 @@ matrix:
 
     # BSD
     - env: TARGET=i686-unknown-freebsd                  DYLIB=1 STD=1 OPENSSL=0.7.17
-    - env: TARGET=x86_64-unknown-dragonfly               DYLIB=1       OPENSSL=0.5.5
+    - env: TARGET=x86_64-unknown-dragonfly              DYLIB=1       OPENSSL=0.5.5
     - env: TARGET=x86_64-unknown-freebsd                DYLIB=1 STD=1 OPENSSL=0.5.5
     - env: TARGET=x86_64-unknown-netbsd                 DYLIB=1 STD=1 OPENSSL=0.7.17
 

--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ worst, "hang" (never terminate).
 
 | Target                               |  libc  |   GCC   | OpenSSL | C++ | QEMU  | `test` |
 |--------------------------------------|--------|---------|---------|:---:|-------|:------:|
-| `aarch64-linux-android`              | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `aarch64-linux-android` [5]          | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |   ✓    |
 | `aarch64-unknown-linux-gnu`          | 2.19   | 4.8.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
-| `arm-linux-androideabi`              | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `arm-linux-androideabi` [5]          | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |   ✓    |
 | `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.15 | 5.3.1   | N/A     |     | 2.8.0 |   ✓    |
-| `armv7-linux-androideabi`            | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `armv7-linux-androideabi` [5]        | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |   ✓    |
 | `armv7-unknown-linux-gnueabihf`      | 2.15   | 4.6.2   | 1.0.2k  | ✓   | 2.8.0 |   ✓    |
 | `armv7-unknown-linux-musleabihf`     | 1.1.15 | 5.3.1   | N/A     |     | 2.8.0 |   ✓    |
 | `asmjs-unknown-emscripten` [4]       | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
-| `i686-linux-android`                 | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `i686-linux-android` [5]             | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 6.2.0   | N/A     | ✓   | N/A   |   ✓    |
 | `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2k  |     | N/A   |        |
 | `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | 1.0.2k  | ✓   | N/A   |   ✓    |
@@ -217,7 +217,7 @@ worst, "hang" (never terminate).
 | `thumbv7em-none-eabihf` [3]          | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
 | `thumbv7m-none-eabi` [3]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
 | `wasm32-unknown-emscripten` [4]      | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
-| `x86_64-linux-android`               | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |        |
+| `x86_64-linux-android` [5]           | N/A    | 4.9     | 1.0.2k  | ✓   | N/A   |   ✓    |
 | `x86_64-pc-windows-gnu`              | N/A    | 6.2.0   | N/A     | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2k  |     | N/A   |   ✓    |
 | `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2k  |     | N/A   |        |
@@ -234,6 +234,9 @@ where libc was extracted.
 
 [4] libc = musl, gcc = emcc; Some projects that use libc may fail due to wrong
     definitions (will be fixed by https://github.com/rust-lang/libc/pull/610)
+
+[5] Only works with native tests, that is, tests that do not depends on the
+    Android Runtime
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,10 @@ where libc was extracted.
     definitions (will be fixed by https://github.com/rust-lang/libc/pull/610)
 
 [5] Only works with native tests, that is, tests that do not depends on the
-    Android Runtime
+    Android Runtime. For i686 some tests may fails with the error `assertion
+    failed: signal(libc::SIGPIPE, libc::SIG_IGN) != libc::SIG_ERR`, see
+    [issue #140](https://github.com/japaric/cross/issues/140) for more
+    information.
 
 ## Debugging
 

--- a/docker/aarch64-linux-android/Dockerfile
+++ b/docker/aarch64-linux-android/Dockerfile
@@ -35,6 +35,7 @@ ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
+    RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \
     ANDROID_ROOT=/system \

--- a/docker/aarch64-linux-android/Dockerfile
+++ b/docker/aarch64-linux-android/Dockerfile
@@ -12,12 +12,18 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+COPY qemu.sh /
+RUN bash /qemu.sh aarch64 android
+
 COPY android-ndk.sh /
 RUN bash /android-ndk.sh arm64 21
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY openssl.sh /
 RUN bash /openssl.sh linux-generic64 aarch64-linux-android- -mandroid -fomit-frame-pointer
+
+COPY android-system.sh /
+RUN bash /android-system.sh arm64
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
@@ -29,5 +35,7 @@ ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
-    RUST_TEST_THREADS=1 \
-    HOME=/tmp/
+    HOME=/tmp/ \
+    TMPDIR=/tmp/ \
+    ANDROID_ROOT=/system \
+    ANDROID_DATA=/

--- a/docker/aarch64-linux-android/Dockerfile
+++ b/docker/aarch64-linux-android/Dockerfile
@@ -28,6 +28,7 @@ RUN bash /android-system.sh arm64
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
+    CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER=qemu-aarch64 \
     CC_aarch64_linux_android=aarch64-linux-android-gcc \
     CXX_aarch64_linux_android=aarch64-linux-android-g++ \
     DEP_Z_ROOT=/android-ndk/sysroot/usr/ \

--- a/docker/android-system.sh
+++ b/docker/android-system.sh
@@ -1,0 +1,102 @@
+set -ex
+
+main() {
+    local arch=$1
+    local td=$(mktemp -d)
+    pushd $td
+
+    local dependencies=(
+        ca-certificates
+        curl
+        gcc-multilib
+        git
+        g++-multilib
+        make
+        python
+    )
+
+    # fake java and javac, it is not necessary for what we build, but the build
+    # script ask for it
+    cat << EOF > /usr/bin/java
+#!/bin/bash
+echo "java version \"1.7.0\""
+echo "OpenJDK Runtime Environment (IcedTea 2.6.9)"
+echo "OpenJDK 64-Bit Server VM (build 24.131-b00, mixed mode)"
+EOF
+
+    cat << EOF > /usr/bin/javac
+#!/bin/bash
+echo "javac 1.7.0"
+EOF
+
+    chmod +x /usr/bin/java
+    chmod +x /usr/bin/javac
+
+    # more faking
+    export ANDROID_JAVA_HOME=/tmp
+    mkdir /tmp/lib/
+    touch /tmp/lib/tools.jar
+
+    apt-get update
+    local purge_list=(default-jre)
+    for dep in ${dependencies[@]}; do
+        if ! dpkg -L $dep; then
+            apt-get install --no-install-recommends -y $dep
+            purge_list+=( $dep )
+        fi
+    done
+
+    curl -O https://storage.googleapis.com/git-repo-downloads/repo
+    chmod +x repo
+
+    # this is the minimum set of modules that are need to build bionic
+    # this was created by trial and error
+    ./repo init -u https://android.googlesource.com/platform/manifest -b android-5.0.0_r1
+    ./repo sync bionic
+    ./repo sync build
+    ./repo sync external/compiler-rt
+    ./repo sync external/jemalloc
+    ./repo sync external/libcxx
+    ./repo sync external/libcxxabi
+    ./repo sync external/stlport
+    ./repo sync prebuilts/clang/linux-x86/host/3.5
+    ./repo sync system/core
+    case $arch in
+        arm)
+            ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
+        ;;
+        arm64)
+            ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
+            ./repo sync prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9
+        ;;
+        x86)
+            ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
+        ;;
+        x86_64)
+            ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
+        ;;
+    esac
+
+    # avoid build tests
+    rm bionic/linker/tests/Android.mk bionic/tests/Android.mk
+
+    source build/envsetup.sh
+    lunch aosp_$arch-user
+    mmma bionic/
+
+    if [ $arch = "arm" ]; then
+        mv out/target/product/generic/system/ /
+    else
+        mv out/target/product/generic_$arch/system/ /
+    fi
+
+    # clean up
+    apt-get purge --auto-remove -y ${purge_list[@]}
+
+    popd
+
+    rm -rf $td
+    rm $0
+}
+
+main "${@}"

--- a/docker/arm-linux-androideabi/Dockerfile
+++ b/docker/arm-linux-androideabi/Dockerfile
@@ -28,6 +28,7 @@ RUN bash /android-system.sh arm
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
+    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER=qemu-arm \
     CC_arm_linux_androideabi=arm-linux-androideabi-gcc \
     CXX_arm_linux_androideabi=arm-linux-androideabi-g++ \
     DEP_Z_ROOT=/android-ndk/sysroot/usr/ \

--- a/docker/arm-linux-androideabi/Dockerfile
+++ b/docker/arm-linux-androideabi/Dockerfile
@@ -12,12 +12,18 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+COPY qemu.sh /
+RUN bash /qemu.sh arm android
+
 COPY android-ndk.sh /
 RUN bash /android-ndk.sh arm 21
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY openssl.sh /
 RUN bash /openssl.sh android arm-linux-androideabi-
+
+COPY android-system.sh /
+RUN bash /android-system.sh arm
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
@@ -29,5 +35,7 @@ ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
-    RUST_TEST_THREADS=1 \
-    HOME=/tmp/
+    HOME=/tmp/ \
+    TMPDIR=/tmp/ \
+    ANDROID_ROOT=/system \
+    ANDROID_DATA=/

--- a/docker/arm-linux-androideabi/Dockerfile
+++ b/docker/arm-linux-androideabi/Dockerfile
@@ -35,6 +35,7 @@ ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
+    RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \
     ANDROID_ROOT=/system \

--- a/docker/armv7-linux-androideabi/Dockerfile
+++ b/docker/armv7-linux-androideabi/Dockerfile
@@ -28,6 +28,7 @@ RUN bash /android-system.sh arm
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
+    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUNNER=qemu-arm \
     CC_armv7_linux_androideabi=arm-linux-androideabi-gcc \
     CXX_armv7_linux_androideabi=arm-linux-androideabi-g++ \
     DEP_Z_ROOT=/android-ndk/sysroot/usr/ \

--- a/docker/armv7-linux-androideabi/Dockerfile
+++ b/docker/armv7-linux-androideabi/Dockerfile
@@ -20,7 +20,7 @@ RUN bash /android-ndk.sh arm 21
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY openssl.sh /
-RUN bash /openssl.sh android arm-linux-androideabi-
+RUN bash /openssl.sh android-armv7 arm-linux-androideabi-
 
 COPY android-system.sh /
 RUN bash /android-system.sh arm
@@ -35,6 +35,7 @@ ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
+    RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \
     ANDROID_ROOT=/system \

--- a/docker/armv7-linux-androideabi/Dockerfile
+++ b/docker/armv7-linux-androideabi/Dockerfile
@@ -12,12 +12,18 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+COPY qemu.sh /
+RUN bash /qemu.sh arm android
+
 COPY android-ndk.sh /
 RUN bash /android-ndk.sh arm 21
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY openssl.sh /
-RUN bash /openssl.sh android-armv7 arm-linux-androideabi-
+RUN bash /openssl.sh android arm-linux-androideabi-
+
+COPY android-system.sh /
+RUN bash /android-system.sh arm
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
@@ -29,5 +35,7 @@ ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
-    RUST_TEST_THREADS=1 \
-    HOME=/tmp/
+    HOME=/tmp/ \
+    TMPDIR=/tmp/ \
+    ANDROID_ROOT=/system \
+    ANDROID_DATA=/

--- a/docker/i686-linux-android/Dockerfile
+++ b/docker/i686-linux-android/Dockerfile
@@ -12,16 +12,31 @@ RUN apt-get update && \
 COPY xargo.sh /
 RUN bash /xargo.sh
 
+# We could supposedly directly run i686 binaries like we do for x86_64, but
+# doing so generates an assertion failure:
+#   ... assertion failed: signal(libc::SIGPIPE, libc::SIG_IGN) != libc::SIG_ERR
+#   ... src/libstd/sys/unix/mod.rs
+#   fatal runtime error: failed to initiate panic, error 5
+#
+# Running with qemu works as expected
+COPY qemu.sh /
+RUN bash /qemu.sh i386 android
+
 COPY android-ndk.sh /
 RUN bash /android-ndk.sh x86 21
 ENV PATH=$PATH:/android-ndk/bin
 
+# Build with no-asm to make openssl linked binaries position-independent (PIE)
 COPY openssl.sh /
-RUN bash /openssl.sh android-x86 i686-linux-android-
+RUN bash /openssl.sh android-x86 i686-linux-android- no-asm
+
+COPY android-system.sh /
+RUN bash /android-system.sh x86
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
+    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER=qemu-i386 \
     CC_i686_linux_android=i686-linux-android-gcc \
     CXX_i686_linux_android=i686-linux-android-g++ \
     DEP_Z_ROOT=/android-ndk/sysroot/usr/ \
@@ -29,5 +44,7 @@ ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
-    RUST_TEST_THREADS=1 \
-    HOME=/tmp/
+    HOME=/tmp/ \
+    TMPDIR=/tmp/ \
+    ANDROID_ROOT=/system \
+    ANDROID_DATA=/

--- a/docker/i686-linux-android/Dockerfile
+++ b/docker/i686-linux-android/Dockerfile
@@ -44,6 +44,7 @@ ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
+    RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \
     ANDROID_ROOT=/system \

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -1,9 +1,10 @@
 set -ex
 
 main() {
-    local version=2.9.0
+    local version=2.10.0
 
     local arch=$1 \
+          target=$2 \
           td=$(mktemp -d)
 
     local dependencies=(
@@ -15,6 +16,7 @@ main() {
         libglib2.0-dev
         libtool
         make
+        patch
         pkg-config
         zlib1g-dev
     )
@@ -32,6 +34,67 @@ main() {
 
     curl -L http://wiki.qemu-project.org/download/qemu-$version.tar.bz2 | \
         tar --strip-components=1 -xj
+
+    # Allow qemu to run android (bionic libc) binaries
+    if [[ "$target" == "android" ]]; then
+      patch -p1 <<'EOF'
+diff -ur qemu-2.10.0/linux-user/elfload.c qemu-2.10.0.new/linux-user/elfload.c
+--- qemu-2.10.0/linux-user/elfload.c	2017-09-27 11:27:13.866595788 -0300
++++ qemu-2.10.0.new/linux-user/elfload.c	2017-09-27 11:58:30.662613425 -0300
+@@ -1354,7 +1354,7 @@
+                                  ~(abi_ulong)(TARGET_ELF_EXEC_PAGESIZE-1))
+ #define TARGET_ELF_PAGEOFFSET(_v) ((_v) & (TARGET_ELF_EXEC_PAGESIZE-1))
+ 
+-#define DLINFO_ITEMS 14
++#define DLINFO_ITEMS 15
+ 
+ static inline void memcpy_fromfs(void * to, const void * from, unsigned long n)
+ {
+@@ -1782,6 +1782,7 @@
+     NEW_AUX_ENT(AT_HWCAP, (abi_ulong) ELF_HWCAP);
+     NEW_AUX_ENT(AT_CLKTCK, (abi_ulong) sysconf(_SC_CLK_TCK));
+     NEW_AUX_ENT(AT_RANDOM, (abi_ulong) u_rand_bytes);
++    NEW_AUX_ENT(AT_SECURE, (abi_ulong)0);
+ 
+ #ifdef ELF_HWCAP2
+     NEW_AUX_ENT(AT_HWCAP2, (abi_ulong) ELF_HWCAP2);
+diff -ur qemu-2.10.0/linux-user/ioctls.h qemu-2.10.0.new/linux-user/ioctls.h
+--- qemu-2.10.0/linux-user/ioctls.h	2017-09-27 11:27:13.858595669 -0300
++++ qemu-2.10.0.new/linux-user/ioctls.h	2017-09-27 11:43:40.613299859 -0300
+@@ -430,6 +430,7 @@
+                 MK_PTR(MK_STRUCT(STRUCT_rtentry)))
+   IOCTL_SPECIAL(SIOCDELRT, IOC_W, do_ioctl_rt,
+                 MK_PTR(MK_STRUCT(STRUCT_rtentry)))
++  IOCTL(RNDGETENTCNT, IOC_R, MK_PTR(TYPE_INT))
+ 
+ #ifdef TARGET_TIOCSTART
+   IOCTL_IGNORE(TIOCSTART)
+diff -ur qemu-2.10.0/linux-user/syscall.c qemu-2.10.0.new/linux-user/syscall.c
+--- qemu-2.10.0/linux-user/syscall.c	2017-09-27 11:27:13.862595729 -0300
++++ qemu-2.10.0.new/linux-user/syscall.c	2017-09-27 11:44:26.133987660 -0300
+@@ -55,6 +55,7 @@
+ //#include <sys/user.h>
+ #include <netinet/ip.h>
+ #include <netinet/tcp.h>
++#include <linux/random.h>
+ #include <linux/wireless.h>
+ #include <linux/icmp.h>
+ #include <linux/icmpv6.h>
+diff -ur qemu-2.10.0/linux-user/syscall_defs.h qemu-2.10.0.new/linux-user/syscall_defs.h
+--- qemu-2.10.0/linux-user/syscall_defs.h	2017-09-27 11:27:13.862595729 -0300
++++ qemu-2.10.0.new/linux-user/syscall_defs.h	2017-09-27 11:46:09.303545817 -0300
+@@ -971,6 +971,8 @@
+     short revents;    /* returned events */
+ };
+ 
++#define TARGET_RNDGETENTCNT    TARGET_IOR('R', 0x00, int)
++
+ /* virtual terminal ioctls */
+ #define TARGET_KIOCSOUND       0x4B2F	/* start sound generation (0 for off) */
+ #define TARGET_KDMKTONE	       0x4B30	/* generate tone */
+EOF
+   fi
+
     ./configure \
         --disable-kvm \
         --disable-vnc \

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -4,7 +4,7 @@ main() {
     local version=2.10.0
 
     local arch=$1 \
-          target=$2 \
+          os=$2 \
           td=$(mktemp -d)
 
     local dependencies=(
@@ -36,7 +36,9 @@ main() {
         tar --strip-components=1 -xj
 
     # Allow qemu to run android (bionic libc) binaries
-    if [[ "$target" == "android" ]]; then
+    # AT_SECURE change is based on https://gist.github.com/whitequark/ad704d48a86d889b8cdb
+    # RNDGETENTCNT change forward ioctl(_, RNDGETENTCNT, _) to the host
+    if [[ "$os" == "android" ]]; then
       patch -p1 <<'EOF'
 diff -ur qemu-2.10.0/linux-user/elfload.c qemu-2.10.0.new/linux-user/elfload.c
 --- qemu-2.10.0/linux-user/elfload.c	2017-09-27 11:27:13.866595788 -0300

--- a/docker/x86_64-linux-android/Dockerfile
+++ b/docker/x86_64-linux-android/Dockerfile
@@ -19,6 +19,9 @@ ENV PATH=$PATH:/android-ndk/bin
 COPY openssl.sh /
 RUN bash /openssl.sh linux-x86_64 x86_64-linux-android- -mandroid -fomit-frame-pointer
 
+COPY android-system.sh /
+RUN bash /android-system.sh x86_64
+
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
@@ -29,5 +32,7 @@ ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
-    RUST_TEST_THREADS=1 \
-    HOME=/tmp/
+    HOME=/tmp/ \
+    TMPDIR=/tmp/ \
+    ANDROID_ROOT=/system \
+    ANDROID_DATA=/


### PR DESCRIPTION
We could provide android test support by launching an android emulator and running tests in the emulator (like how it is done in libc and rust), but there is licenses issues in redistributing the sdk (see 3.4 of https://developer.android.com/studio/terms.html). Off course, I maybe be wrong about this.

So we download and build bionic libc from source, which I think allows we to distribute the binaries. Having the android libc allows running native binaries using qemu, which can be enough for projects like, nix, ripgrep, etc.

Related https://github.com/japaric/cross/issues/82