### PR TITLE
Support OpenSSL on i686 musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - env: TARGET=armv7-unknown-linux-gnueabihf   CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=armv7-unknown-linux-musleabihf                STD=1                RUN=1
     - env: TARGET=i686-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
-    - env: TARGET=i686-unknown-linux-musl                       STD=1                RUN=1
+    - env: TARGET=i686-unknown-linux-musl                       STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=mips-unknown-linux-gnu          CPP=1 DYLIB=1 STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=mips64-unknown-linux-gnuabi64   CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1
     - env: TARGET=mips64el-unknown-linux-gnuabi64 CPP=1 DYLIB=1 STD=1 OPENSSL=0.7.17 RUN=1

--- a/docker/i686-unknown-linux-musl/Dockerfile
+++ b/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM i386/ubuntu:16.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -18,3 +18,12 @@ RUN apt-get install -y --no-install-recommends \
     bash /musl.sh 1.1.15 i386 -m32
 
 ENV CC_i686_unknown_linux_musl=musl-gcc
+
+COPY openssl.sh /
+RUN apt-get install -y --no-install-recommends \
+    g++-multilib && \
+    bash /openssl.sh linux-elf musl- -m32
+
+ENV OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include \
+    OPENSSL_LIB_DIR=/openssl/lib


### PR DESCRIPTION
Changing the base image of `i686-unknown-linux-musl` from `ubuntu/16.04`
to `i386/ubuntu:16.04` allows us to compile OpenSSL using musl. The
image is based on a 32bit Ubuntu kernel.

Fixes #27

Not entirely sure what else needs to change for the build process, for now I've added the OPENSSL env var to the build matrix. Should be good?