### PR TITLE
Use Solaris 10 compatible compiler triplet

### DIFF
--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -5,7 +5,7 @@ main() {
 
     local binutils=2.25.1 \
           gcc=5.3.0 \
-          target=$arch-sun-solaris2.11
+          target=$arch-sun-solaris2.10
 
     local dependencies=(
         bzip2

--- a/docker/sparcv9-sun-solaris/Dockerfile
+++ b/docker/sparcv9-sun-solaris/Dockerfile
@@ -14,10 +14,10 @@ RUN bash /xargo.sh
 
 COPY solaris.sh openssl.sh /
 RUN bash /solaris.sh sparcv9 && \
-    bash /openssl.sh solaris64-sparcv9-gcc sparcv9-sun-solaris2.11-
+    bash /openssl.sh solaris64-sparcv9-gcc sparcv9-sun-solaris2.10-
 
-ENV CARGO_TARGET_SPARCV9_SUN_SOLARIS_LINKER=sparcv9-sun-solaris2.11-gcc \
-    CC_sparcv9_sun_solaris=sparcv9-sun-solaris2.11-gcc \
+ENV CARGO_TARGET_SPARCV9_SUN_SOLARIS_LINKER=sparcv9-sun-solaris2.10-gcc \
+    CC_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-sun-solaris/Dockerfile
+++ b/docker/x86_64-sun-solaris/Dockerfile
@@ -14,10 +14,10 @@ RUN bash /xargo.sh
 
 COPY solaris.sh openssl.sh /
 RUN bash /solaris.sh x86_64 && \
-    bash /openssl.sh solaris64-x86_64-gcc x86_64-sun-solaris2.11-
+    bash /openssl.sh solaris64-x86_64-gcc x86_64-sun-solaris2.10-
 
-ENV CARGO_TARGET_X86_64_SUN_SOLARIS_LINKER=x86_64-sun-solaris2.11-gcc \
-    CC_x86_64_sun_solaris=x86_64-sun-solaris2.11-gcc \
+ENV CARGO_TARGET_X86_64_SUN_SOLARIS_LINKER=x86_64-sun-solaris2.10-gcc \
+    CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib


### PR DESCRIPTION
This changes the solaris2.11 part of the gcc triplet
to solaris2.10, because there is a compatibility issue:
If a rust program panics on Solaris 10 the backtrace
cannot be generated because of a runtime error.

Changing the triplet works for both Solaris 10 and 11.
It is also the same triplet that is used by Rust's CI.