### PR TITLE
Use -cpu n270 to run i686-linux-android binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ matrix:
     - env: TARGET=aarch64-linux-android           CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=arm-linux-androideabi           CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=armv7-linux-androideabi         CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
-    # NOTE RUN=1 missing due to issue #143
-    - env: TARGET=i686-linux-android              CPP=1         STD=1 OPENSSL=0.5.5
+    - env: TARGET=i686-linux-android              CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
     - env: TARGET=x86_64-linux-android            CPP=1         STD=1 OPENSSL=0.5.5  RUN=1
 
     # OSX

--- a/docker/i686-linux-android/Dockerfile
+++ b/docker/i686-linux-android/Dockerfile
@@ -36,7 +36,7 @@ RUN bash /android-system.sh x86
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
-    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER=qemu-i386 \
+    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="qemu-i386 -cpu n270" \
     CC_i686_linux_android=i686-linux-android-gcc \
     CXX_i686_linux_android=i686-linux-android-g++ \
     DEP_Z_ROOT=/android-ndk/sysroot/usr/ \


### PR DESCRIPTION
After the ndk update used to build libstd https://github.com/rust-lang/rust/pull/45580, i686-linux-android binaries stopped working https://github.com/japaric/cross/issues/143. It's seem that the new toolchain is emitting instructions that the default qemu-i386 cpu does not support. Using -cpu n270 (common in android i686 phones), fix the problem.

Fixes https://github.com/japaric/cross/issues/143.