### PR TITLE
Add C++ support for BSDs and Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ worst, "hang" (never terminate).
 | `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-linux-android` [5]             | N/A    | 4.9     | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 6.2.0   | N/A     | ✓   | N/A   |   ✓    |
-| `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2m  |     | N/A   |        |
+| `i686-unknown-freebsd` [1]           | 10.2   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.15 | 5.3.1   | 1.0.2m  |     | N/A   |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.23   | 5.3.1   | 1.0.2m  | ✓   | 2.8.0 |   ✓    |
@@ -213,7 +213,7 @@ worst, "hang" (never terminate).
 | `powerpc64le-unknown-linux-gnu`      | 2.19   | 4.8.2   | 1.0.2m  | ✓   | 2.7.1 |   ✓    |
 | `s390x-unknown-linux-gnu`            | 2.23   | 5.3.1   | 1.0.2m  | ✓   | 2.8.0 |        |
 | `sparc64-unknown-linux-gnu` [2]      | 2.23   | 5.3.1   | 1.0.2m  | ✓   | 2.8.0 |   ✓    |
-| `sparcv9-sun-solaris` [1]            | 2.11   | 5.3.0   | 1.0.2m  |     | N/A   |        |
+| `sparcv9-sun-solaris` [1]            | 2.11   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `thumbv6m-none-eabi` [3]             | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
 | `thumbv7em-none-eabi` [3]            | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
 | `thumbv7em-none-eabihf` [3]          | 2.2.0  | 5.3.1   | N/A     |     | N/A   |        |
@@ -221,12 +221,12 @@ worst, "hang" (never terminate).
 | `wasm32-unknown-emscripten` [4]      | 1.1.15 | 1.37.13 | N/A     | ✓   | N/A   |   ✓    |
 | `x86_64-linux-android` [5]           | N/A    | 4.9     | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `x86_64-pc-windows-gnu`              | N/A    | 6.2.0   | N/A     | ✓   | N/A   |   ✓    |
-| `x86_64-sun-solaris` [1]             | 2.11   | 5.3.0   | 1.0.2m  |     | N/A   |        |
-| `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2m  |     | N/A   |   ✓    |
-| `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2m  |     | N/A   |        |
+| `x86_64-sun-solaris` [1]             | 2.11   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
+| `x86_64-unknown-dragonfly` [1] [2]   | 4.6.0  | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
+| `x86_64-unknown-freebsd` [1]         | 10.2   | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 | `x86_64-unknown-linux-gnu`           | 2.15   | 4.6.2   | 1.0.2m  | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-linux-musl`          | 1.1.15 | 5.3.1   | 1.0.2m  |     | N/A   |   ✓    |
-| `x86_64-unknown-netbsd`[1]           | 7.0    | 5.3.0   | 1.0.2m  |     | N/A   |        |
+| `x86_64-unknown-netbsd`[1]           | 7.0    | 5.3.0   | 1.0.2m  | ✓   | N/A   |        |
 
 [1] For *BSD and Solaris targets, the libc column indicates the OS release version from
 where libc was extracted.

--- a/docker/i686-unknown-freebsd/Dockerfile
+++ b/docker/i686-unknown-freebsd/Dockerfile
@@ -18,6 +18,7 @@ RUN bash /freebsd.sh i686 && \
 
 ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER=i686-unknown-freebsd10-gcc \
     CC_i686_unknown_freebsd=i686-unknown-freebsd10-gcc \
+    CXX_i686_unknown_freebsd=i686-unknown-freebsd10-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/sparcv9-sun-solaris/Dockerfile
+++ b/docker/sparcv9-sun-solaris/Dockerfile
@@ -18,6 +18,7 @@ RUN bash /solaris.sh sparcv9 && \
 
 ENV CARGO_TARGET_SPARCV9_SUN_SOLARIS_LINKER=sparcv9-sun-solaris2.10-gcc \
     CC_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-gcc \
+    CXX_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-sun-solaris/Dockerfile
+++ b/docker/x86_64-sun-solaris/Dockerfile
@@ -18,6 +18,7 @@ RUN bash /solaris.sh x86_64 && \
 
 ENV CARGO_TARGET_X86_64_SUN_SOLARIS_LINKER=x86_64-sun-solaris2.10-gcc \
     CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
+    CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-dragonfly/Dockerfile
+++ b/docker/x86_64-unknown-dragonfly/Dockerfile
@@ -18,6 +18,7 @@ RUN bash /dragonfly.sh && \
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_DRAGONFLY_LINKER=x86_64-unknown-dragonfly-gcc \
     CC_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-gcc \
+    CXX_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/docker/x86_64-unknown-freebsd/Dockerfile
@@ -18,6 +18,7 @@ RUN bash /freebsd.sh x86_64 && \
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd10-gcc \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-gcc \
+    CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib

--- a/docker/x86_64-unknown-netbsd/Dockerfile
+++ b/docker/x86_64-unknown-netbsd/Dockerfile
@@ -18,6 +18,7 @@ RUN bash /netbsd.sh && \
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_NETBSD_LINKER=x86_64-unknown-netbsd-gcc \
     CC_x86_64_unknown_netbsd=x86_64-unknown-netbsd-gcc \
+    CXX_x86_64_unknown_netbsd=x86_64-unknown-netbsd-g++ \
     OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib


### PR DESCRIPTION
The g++ is already built, but is not referenced as an environment variable.
Adds the missing environment variables and documents them in README.